### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rc-zip"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bzip2",
  "cfg-if",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-sync"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-tokio"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "futures",
  "oval",

--- a/rc-zip-sync/CHANGELOG.md
+++ b/rc-zip-sync/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-sync-v3.0.0...rc-zip-sync-v4.0.0) - 2024-02-05
+
+### Added
+- [**breaking**] Introduce `ReadZipStreaming` trait ([#62](https://github.com/fasterthanlime/rc-zip/pull/62))
+
+### Fixed
+- Windows build was failing
+
+### Other
+- Remove unused dependencies
+
 ## [3.0.0](https://github.com/fasterthanlime/rc-zip/releases/tag/rc-zip-sync-v3.0.0) - 2024-02-02
 
 ### Other

--- a/rc-zip-sync/Cargo.toml
+++ b/rc-zip-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-sync"
-version = "3.0.0"
+version = "4.0.0"
 description = "Synchronous zip reading on top of rc-zip"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"
@@ -21,7 +21,7 @@ path = "examples/jean.rs"
 
 [dependencies]
 positioned-io = { version = "0.3.3", optional = true }
-rc-zip = { version = "3.0.0", path = "../rc-zip" }
+rc-zip = { version = "4.0.0", path = "../rc-zip" }
 oval = "2.0.0"
 tracing = "0.1.40"
 
@@ -41,5 +41,5 @@ humansize = "2.1.3"
 indicatif = "0.17.7"
 test-log = { version = "0.2.14", default-features = false, features = ["tracing-subscriber", "trace"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rc-zip = { version = "3.0.0", path = "../rc-zip", features = ["corpus"] }
+rc-zip = { version = "4.0.0", path = "../rc-zip", features = ["corpus"] }
 cfg-if = "1.0.0"

--- a/rc-zip-tokio/CHANGELOG.md
+++ b/rc-zip-tokio/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-tokio-v3.0.0...rc-zip-tokio-v4.0.0) - 2024-02-05
+
+### Added
+- [**breaking**] Introduce `ReadZipStreaming` trait ([#62](https://github.com/fasterthanlime/rc-zip/pull/62))
+
 ## [3.0.0](https://github.com/fasterthanlime/rc-zip/releases/tag/rc-zip-tokio-v3.0.0) - 2024-02-02
 
 ### Other

--- a/rc-zip-tokio/Cargo.toml
+++ b/rc-zip-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-tokio"
-version = "3.0.0"
+version = "4.0.0"
 description = "Asynchronous zip reading on top of rc-zip (for tokio I/O traits)"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"
@@ -17,7 +17,7 @@ name = "rc_zip_tokio"
 path = "src/lib.rs"
 
 [dependencies]
-rc-zip = { version = "3.0.0", path = "../rc-zip" }
+rc-zip = { version = "4.0.0", path = "../rc-zip" }
 positioned-io = { version = "0.3.3" }
 tokio = { version = "1.35.1", features = ["fs", "io-util", "rt-multi-thread"] }
 futures = { version = "0.3.30" }
@@ -36,5 +36,5 @@ zstd = ["rc-zip/zstd"]
 [dev-dependencies]
 test-log = { version = "0.2.14", default-features = false, features = ["tracing-subscriber", "trace"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rc-zip = { version = "3.0.0", path = "../rc-zip", features = ["corpus"] }
+rc-zip = { version = "4.0.0", path = "../rc-zip", features = ["corpus"] }
 tokio = { version = "1.35.1", features = ["rt", "macros"] }

--- a/rc-zip/CHANGELOG.md
+++ b/rc-zip/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-v3.0.0...rc-zip-v4.0.0) - 2024-02-05
+
+### Added
+- [**breaking**] Introduce `ReadZipStreaming` trait ([#62](https://github.com/fasterthanlime/rc-zip/pull/62))
+
+### Other
+- Remove unused dependencies
+
 ## [3.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-v2.0.1...rc-zip-v3.0.0) - 2024-02-02
 
 ### Other

--- a/rc-zip/Cargo.toml
+++ b/rc-zip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip"
-version = "3.0.0"
+version = "4.0.0"
 description = "An I/O-agnostic implementation of the zip file format"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `rc-zip`: 3.0.0 -> 4.0.0 (⚠️ API breaking changes)
* `rc-zip-sync`: 3.0.0 -> 4.0.0 (⚠️ API breaking changes)
* `rc-zip-tokio`: 3.0.0 -> 4.0.0 (⚠️ API breaking changes)

### ⚠️ `rc-zip` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ExtraZip64Field.disk_start in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/extra_field.rs:136
  field Entry.header_offset in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:113
  field Entry.reader_version in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:116
  field Entry.flags in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:125
  field Entry.uid in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:130
  field Entry.gid in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:135
  field Entry.crc32 in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:141
  field Entry.compressed_size in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:144
  field Entry.uncompressed_size in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:149
  field Entry.mode in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/archive.rs:152

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/enum_missing.ron

Failed in:
  enum rc_zip::parse::EntryContents, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/archive.rs:271

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/inherent_method_missing.ron

Failed in:
  Version::host_system, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/version.rs:32
  Version::host, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/version.rs:59
  Version::version, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/version.rs:64
  Version::major, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/version.rs:71
  Version::minor, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/version.rs:78

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/struct_missing.ron

Failed in:
  struct rc_zip::parse::StoredEntry, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/archive.rs:93
  struct rc_zip::parse::ZipString, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/raw.rs:10
  struct rc_zip::parse::StoredEntryInner, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/archive.rs:159
  struct rc_zip::parse::DirectoryHeader, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/directory_header.rs:22
  struct rc_zip::parse::ZipBytes, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/raw.rs:50
  struct rc_zip::parse::LocalFileHeaderRecord, previously in file /tmp/.tmpL0h8Ft/rc-zip/src/parse/local.rs:17

--- failure tuple_struct_to_plain_struct: tuple struct changed to plain struct ---

Description:
A publicly-visible, exhaustive tuple struct with pub fields changed to normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/tuple_struct_to_plain_struct.ron

Failed in:
  struct Version in /tmp/.tmpI93ulR/rc-zip/rc-zip/src/parse/version.rs:13
```

### ⚠️ `rc-zip-sync` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/struct_missing.ron

Failed in:
  struct rc_zip_sync::SyncArchive, previously in file /tmp/.tmpL0h8Ft/rc-zip-sync/src/read_zip.rs:92
  struct rc_zip_sync::SyncStoredEntry, previously in file /tmp/.tmpL0h8Ft/rc-zip-sync/src/read_zip.rs:137
```

### ⚠️ `rc-zip-tokio` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/struct_missing.ron

Failed in:
  struct rc_zip_tokio::AsyncStoredEntry, previously in file /tmp/.tmpL0h8Ft/rc-zip-tokio/src/async_read_zip.rs:149
  struct rc_zip_tokio::AsyncArchive, previously in file /tmp/.tmpL0h8Ft/rc-zip-tokio/src/async_read_zip.rs:104

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.27.0/src/lints/trait_missing.ron

Failed in:
  trait rc_zip_tokio::HasAsyncCursor, previously in file /tmp/.tmpL0h8Ft/rc-zip-tokio/src/async_read_zip.rs:180
  trait rc_zip_tokio::ReadZipWithSizeAsync, previously in file /tmp/.tmpL0h8Ft/rc-zip-tokio/src/async_read_zip.rs:18
  trait rc_zip_tokio::ReadZipAsync, previously in file /tmp/.tmpL0h8Ft/rc-zip-tokio/src/async_read_zip.rs:35
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rc-zip`
<blockquote>

## [4.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-v3.0.0...rc-zip-v4.0.0) - 2024-02-05

### Added
- [**breaking**] Introduce `ReadZipStreaming` trait ([#62](https://github.com/fasterthanlime/rc-zip/pull/62))

### Other
- Remove unused dependencies
</blockquote>

## `rc-zip-sync`
<blockquote>

## [4.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-sync-v3.0.0...rc-zip-sync-v4.0.0) - 2024-02-05

### Added
- [**breaking**] Introduce `ReadZipStreaming` trait ([#62](https://github.com/fasterthanlime/rc-zip/pull/62))

### Fixed
- Windows build was failing

### Other
- Remove unused dependencies
</blockquote>

## `rc-zip-tokio`
<blockquote>

## [4.0.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-tokio-v3.0.0...rc-zip-tokio-v4.0.0) - 2024-02-05

### Added
- [**breaking**] Introduce `ReadZipStreaming` trait ([#62](https://github.com/fasterthanlime/rc-zip/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).