### PR TITLE
Improve readability of Encoding::display a tiny bit

### DIFF
--- a/rc-zip/src/encoding.rs
+++ b/rc-zip/src/encoding.rs
@@ -30,11 +30,11 @@ pub enum Encoding {
 
 impl fmt::Display for Encoding {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Encoding as T;
+        use Encoding::*;
         match self {
-            T::Utf8 => write!(f, "utf-8"),
-            T::Cp437 => write!(f, "cp-437"),
-            T::ShiftJis => write!(f, "shift-jis"),
+            Utf8 => write!(f, "utf-8"),
+            Cp437 => write!(f, "cp-437"),
+            ShiftJis => write!(f, "shift-jis"),
         }
     }
 }


### PR DESCRIPTION
Hi Amos,

actually, this is more a question than a big improvement. I hope you don't mind 😌 

When matching on the variants of an enum in its implementation, I'm used to importing them into the scope using `use MyEnum::*`. In your code, you chose to use an alias instead. Is this better for any reason? Any gotchas I should be aware of?

Thanks,
Kevin