### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rc-zip"
-version = "5.0.1"
+version = "5.1.0"
 dependencies = [
  "bzip2",
  "cfg-if",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-sync"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-tokio"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "futures-util",
  "oval",

--- a/rc-zip-sync/CHANGELOG.md
+++ b/rc-zip-sync/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-sync-v4.0.1...rc-zip-sync-v4.1.0) - 2024-03-19
+
+### Added
+- Measure code coverage differently ([#79](https://github.com/fasterthanlime/rc-zip/pull/79))
+- Run one-byte-read tests in CI in release ([#77](https://github.com/fasterthanlime/rc-zip/pull/77))
+- rc-zip-tokio: Re-use cursor if it's at the right offset already ([#71](https://github.com/fasterthanlime/rc-zip/pull/71))
+
+### Fixed
+- lzma_dec: count all input in outcome.bytes_read
+
+### Other
+- release ([#68](https://github.com/fasterthanlime/rc-zip/pull/68))
+
 ## [4.0.1](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-sync-v4.0.0...rc-zip-sync-v4.0.1) - 2024-03-12
 
 ### Other

--- a/rc-zip-sync/Cargo.toml
+++ b/rc-zip-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-sync"
-version = "4.0.1"
+version = "4.1.0"
 description = "Synchronous zip reading on top of rc-zip"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"
@@ -21,7 +21,7 @@ path = "examples/jean.rs"
 
 [dependencies]
 positioned-io = { version = "0.3.3", optional = true }
-rc-zip = { version = "5.0.1", path = "../rc-zip" }
+rc-zip = { version = "5.1.0", path = "../rc-zip" }
 oval = "2.0.0"
 tracing = "0.1.40"
 
@@ -40,5 +40,5 @@ clap = { version = "4.4.18", features = ["derive"] }
 humansize = "2.1.3"
 indicatif = "0.17.7"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rc-zip = { version = "5.0.1", path = "../rc-zip", features = ["corpus"] }
+rc-zip = { version = "5.1.0", path = "../rc-zip", features = ["corpus"] }
 cfg-if = "1.0.0"

--- a/rc-zip-tokio/CHANGELOG.md
+++ b/rc-zip-tokio/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-tokio-v4.0.1...rc-zip-tokio-v4.1.0) - 2024-03-19
+
+### Added
+- Measure code coverage differently ([#79](https://github.com/fasterthanlime/rc-zip/pull/79))
+- futures => futures_util (fewer deps)
+- Run one-byte-read tests in CI in release ([#77](https://github.com/fasterthanlime/rc-zip/pull/77))
+- More efficient  implementation
+- rc-zip-tokio: Re-use cursor if it's at the right offset already ([#71](https://github.com/fasterthanlime/rc-zip/pull/71))
+
+### Fixed
+- lzma_dec: count all input in outcome.bytes_read
+- Don't give up on reading local header when given short reads
+- fix arafc bug I just introduced
+
+### Other
+- release ([#68](https://github.com/fasterthanlime/rc-zip/pull/68))
+
 ## [4.0.1](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-tokio-v4.0.0...rc-zip-tokio-v4.0.1) - 2024-03-12
 
 ### Other

--- a/rc-zip-tokio/Cargo.toml
+++ b/rc-zip-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip-tokio"
-version = "4.0.1"
+version = "4.1.0"
 description = "Asynchronous zip reading on top of rc-zip (for tokio I/O traits)"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"
@@ -17,7 +17,7 @@ name = "rc_zip_tokio"
 path = "src/lib.rs"
 
 [dependencies]
-rc-zip = { version = "5.0.1", path = "../rc-zip" }
+rc-zip = { version = "5.1.0", path = "../rc-zip" }
 positioned-io = { version = "0.3.3" }
 tokio = { version = "1.35.1", features = ["fs", "io-util", "rt-multi-thread"] }
 futures-util = { version = "0.3.30" }
@@ -35,5 +35,5 @@ zstd = ["rc-zip/zstd"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rc-zip = { version = "5.0.1", path = "../rc-zip", features = ["corpus"] }
+rc-zip = { version = "5.1.0", path = "../rc-zip", features = ["corpus"] }
 tokio = { version = "1.35.1", features = ["rt", "macros"] }

--- a/rc-zip/CHANGELOG.md
+++ b/rc-zip/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-v5.0.1...rc-zip-v5.1.0) - 2024-03-19
+
+### Added
+- Measure code coverage differently ([#79](https://github.com/fasterthanlime/rc-zip/pull/79))
+- Run one-byte-read tests in CI in release ([#77](https://github.com/fasterthanlime/rc-zip/pull/77))
+- Resolve winnow + chrono deprecations ([#70](https://github.com/fasterthanlime/rc-zip/pull/70))
+
+### Fixed
+- lzma_dec: count all input in outcome.bytes_read
+- In Entry FSM, don't recurse infinitely if buffer doesn't contain full local header
+- Fix doc comment for read_offset
+
+### Other
+- Fix zstd bug similar to lzma bug
+
 ## [5.0.1](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-v5.0.0...rc-zip-v5.0.1) - 2024-03-12
 
 ### Other

--- a/rc-zip/Cargo.toml
+++ b/rc-zip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rc-zip"
-version = "5.0.1"
+version = "5.1.0"
 description = "An I/O-agnostic implementation of the zip file format"
 repository = "https://github.com/fasterthanlime/rc-zip"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## 🤖 New release
* `rc-zip`: 5.0.1 -> 5.1.0 (✓ API compatible changes)
* `rc-zip-sync`: 4.0.1 -> 4.1.0 (✓ API compatible changes)
* `rc-zip-tokio`: 4.0.1 -> 4.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rc-zip`
<blockquote>

## [5.1.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-v5.0.1...rc-zip-v5.1.0) - 2024-03-19

### Added
- Measure code coverage differently ([#79](https://github.com/fasterthanlime/rc-zip/pull/79))
- Run one-byte-read tests in CI in release ([#77](https://github.com/fasterthanlime/rc-zip/pull/77))
- Resolve winnow + chrono deprecations ([#70](https://github.com/fasterthanlime/rc-zip/pull/70))

### Fixed
- lzma_dec: count all input in outcome.bytes_read
- In Entry FSM, don't recurse infinitely if buffer doesn't contain full local header
- Fix doc comment for read_offset

### Other
- Fix zstd bug similar to lzma bug
</blockquote>

## `rc-zip-sync`
<blockquote>

## [4.1.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-sync-v4.0.1...rc-zip-sync-v4.1.0) - 2024-03-19

### Added
- Measure code coverage differently ([#79](https://github.com/fasterthanlime/rc-zip/pull/79))
- Run one-byte-read tests in CI in release ([#77](https://github.com/fasterthanlime/rc-zip/pull/77))
- rc-zip-tokio: Re-use cursor if it's at the right offset already ([#71](https://github.com/fasterthanlime/rc-zip/pull/71))

### Fixed
- lzma_dec: count all input in outcome.bytes_read

### Other
- release ([#68](https://github.com/fasterthanlime/rc-zip/pull/68))
</blockquote>

## `rc-zip-tokio`
<blockquote>

## [4.1.0](https://github.com/fasterthanlime/rc-zip/compare/rc-zip-tokio-v4.0.1...rc-zip-tokio-v4.1.0) - 2024-03-19

### Added
- Measure code coverage differently ([#79](https://github.com/fasterthanlime/rc-zip/pull/79))
- futures => futures_util (fewer deps)
- Run one-byte-read tests in CI in release ([#77](https://github.com/fasterthanlime/rc-zip/pull/77))
- More efficient  implementation
- rc-zip-tokio: Re-use cursor if it's at the right offset already ([#71](https://github.com/fasterthanlime/rc-zip/pull/71))

### Fixed
- lzma_dec: count all input in outcome.bytes_read
- Don't give up on reading local header when given short reads
- fix arafc bug I just introduced

### Other
- release ([#68](https://github.com/fasterthanlime/rc-zip/pull/68))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).