### PR TITLE
feat: Measure code coverage differently

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,4 +2,4 @@
 slow-timeout = { period = "5s", terminate-after = 3 }
 
 [profile.ci]
-slow-timeout = { period = "5s", terminate-after = 6 }
+slow-timeout = { period = "10s", terminate-after = 12 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,9 +785,9 @@ dependencies = [
  "oval",
  "ownable",
  "temp-dir",
- "test-log",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
  "winnow",
  "zstd",
 ]
@@ -804,7 +804,6 @@ dependencies = [
  "oval",
  "positioned-io",
  "rc-zip",
- "test-log",
  "tracing",
  "tracing-subscriber",
 ]
@@ -818,7 +817,6 @@ dependencies = [
  "pin-project-lite",
  "positioned-io",
  "rc-zip",
- "test-log",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -963,27 +961,6 @@ name = "temp-dir"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd16aa9ffe15fe021c6ee3766772132c6e98dfa395a167e16864f61a9cfb71d6"
-
-[[package]]
-name = "test-log"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
-dependencies = [
- "test-log-macros",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "thiserror"

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,11 @@ ci-test:
 	#!/bin/bash -eux
 	source <(cargo llvm-cov show-env --export-prefix)
 	cargo llvm-cov clean --workspace
+
+	export RUST_LOG=trace
 	cargo nextest run --all-features --profile ci
-	ONE_BYTE_READ=1 cargo nextest run --all-features --release --profile ci
-	cargo llvm-cov report --lcov --output-path coverage.lcov
+	export ONE_BYTE_READ=1
+	cargo nextest run --all-features --profile ci
+
+	cargo llvm-cov report --ignore-filename-regex 'corpus/mod\.rs$' --lcov --output-path coverage.lcov
+	cargo llvm-cov report --ignore-filename-regex 'corpus/mod\.rs$' --html

--- a/Justfile
+++ b/Justfile
@@ -24,9 +24,9 @@ ci-test:
 	cargo llvm-cov clean --workspace
 
 	export RUST_LOG=trace
-	cargo nextest run --all-features --profile ci
+	cargo nextest run --release --all-features --profile ci
 	export ONE_BYTE_READ=1
-	cargo nextest run --all-features --profile ci
+	cargo nextest run --release --all-features --profile ci
 
-	cargo llvm-cov report --ignore-filename-regex 'corpus/mod\.rs$' --lcov --output-path coverage.lcov
-	cargo llvm-cov report --ignore-filename-regex 'corpus/mod\.rs$' --html
+	cargo llvm-cov report --release --ignore-filename-regex 'corpus/mod\.rs$' --lcov --output-path coverage.lcov
+	cargo llvm-cov report --release --ignore-filename-regex 'corpus/mod\.rs$' --html

--- a/rc-zip-sync/Cargo.toml
+++ b/rc-zip-sync/Cargo.toml
@@ -39,7 +39,6 @@ chrono = "0.4.33"
 clap = { version = "4.4.18", features = ["derive"] }
 humansize = "2.1.3"
 indicatif = "0.17.7"
-test-log = { version = "0.2.14", default-features = false, features = ["tracing-subscriber", "trace"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 rc-zip = { version = "5.0.1", path = "../rc-zip", features = ["corpus"] }
 cfg-if = "1.0.0"

--- a/rc-zip-sync/tests/integration_tests.rs
+++ b/rc-zip-sync/tests/integration_tests.rs
@@ -30,23 +30,29 @@ fn check_case<F: HasCursor>(test: &Case, archive: Result<ArchiveHandle<'_, F>, E
     }
 }
 
-#[test_log::test]
+#[test]
 fn read_from_slice() {
+    corpus::install_test_subscriber();
+
     let bytes = std::fs::read(zips_dir().join("test.zip")).unwrap();
     let slice = &bytes[..];
     let archive = slice.read_zip().unwrap();
     assert_eq!(archive.entries().count(), 2);
 }
 
-#[test_log::test]
+#[test]
 fn read_from_file() {
+    corpus::install_test_subscriber();
+
     let f = File::open(zips_dir().join("test.zip")).unwrap();
     let archive = f.read_zip().unwrap();
     assert_eq!(archive.entries().count(), 2);
 }
 
-#[test_log::test]
+#[test]
 fn real_world_files() {
+    corpus::install_test_subscriber();
+
     for case in corpus::test_cases() {
         tracing::info!("============ testing {}", case.name);
 
@@ -65,8 +71,10 @@ fn real_world_files() {
     }
 }
 
-#[test_log::test]
+#[test]
 fn streaming() {
+    corpus::install_test_subscriber();
+
     for case in corpus::streaming_test_cases() {
         let guarded_path = case.absolute_path();
         let file = File::open(&guarded_path.path).unwrap();

--- a/rc-zip-tokio/Cargo.toml
+++ b/rc-zip-tokio/Cargo.toml
@@ -34,7 +34,6 @@ bzip2 = ["rc-zip/bzip2"]
 zstd = ["rc-zip/zstd"]
 
 [dev-dependencies]
-test-log = { version = "0.2.14", default-features = false, features = ["tracing-subscriber", "trace"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 rc-zip = { version = "5.0.1", path = "../rc-zip", features = ["corpus"] }
 tokio = { version = "1.35.1", features = ["rt", "macros"] }

--- a/rc-zip-tokio/tests/integration_tests.rs
+++ b/rc-zip-tokio/tests/integration_tests.rs
@@ -27,23 +27,29 @@ async fn check_case<F: HasCursor>(test: &Case, archive: Result<ArchiveHandle<'_,
     }
 }
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn read_from_slice() {
+    corpus::install_test_subscriber();
+
     let bytes = std::fs::read(zips_dir().join("test.zip")).unwrap();
     let slice = &bytes[..];
     let archive = slice.read_zip().await.unwrap();
     assert_eq!(archive.entries().count(), 2);
 }
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn read_from_file() {
+    corpus::install_test_subscriber();
+
     let f = Arc::new(RandomAccessFile::open(zips_dir().join("test.zip")).unwrap());
     let archive = f.read_zip().await.unwrap();
     assert_eq!(archive.entries().count(), 2);
 }
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn real_world_files() {
+    corpus::install_test_subscriber();
+
     for case in corpus::test_cases() {
         tracing::info!("============ testing {}", case.name);
 
@@ -62,8 +68,10 @@ async fn real_world_files() {
     }
 }
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn streaming() {
+    corpus::install_test_subscriber();
+
     for case in corpus::streaming_test_cases() {
         let guarded_path = case.absolute_path();
         let file = tokio::fs::File::open(&guarded_path.path).await.unwrap();

--- a/rc-zip/Cargo.toml
+++ b/rc-zip/Cargo.toml
@@ -34,7 +34,7 @@ lzma-rs = { version = "0.3.0", optional = true, features = ["stream"] }
 zstd = { version = "0.13.0", optional = true }
 ownable = "0.6.2"
 temp-dir = { version = "0.1.12", optional = true }
-tracing-subscriber = { version = "0.3.18", optional = true }
+tracing-subscriber = { version = "0.3.18", optional = true, features = ["env-filter"] }
 
 [features]
 corpus = ["dep:temp-dir", "dep:bzip2", "dep:tracing-subscriber"]

--- a/rc-zip/Cargo.toml
+++ b/rc-zip/Cargo.toml
@@ -34,14 +34,13 @@ lzma-rs = { version = "0.3.0", optional = true, features = ["stream"] }
 zstd = { version = "0.13.0", optional = true }
 ownable = "0.6.2"
 temp-dir = { version = "0.1.12", optional = true }
+tracing-subscriber = { version = "0.3.18", optional = true }
 
 [features]
-corpus = ["dep:temp-dir", "dep:bzip2"]
+corpus = ["dep:temp-dir", "dep:bzip2", "dep:tracing-subscriber"]
 deflate = ["dep:miniz_oxide"]
 deflate64 = ["dep:deflate64"]
 bzip2 = ["dep:bzip2"]
 lzma = ["dep:lzma-rs"]
 zstd = ["dep:zstd"]
-
-[dev-dependencies]
-test-log = { version = "0.2.14", default-features = false, features = ["tracing-subscriber", "trace"] }
+tracing-subscriber = ["dep:tracing-subscriber"]

--- a/rc-zip/tests/integration_tests.rs
+++ b/rc-zip/tests/integration_tests.rs
@@ -5,8 +5,10 @@ use rc_zip::{
     fsm::{ArchiveFsm, FsmResult},
 };
 
-#[test_log::test]
+#[test]
 fn state_machine() {
+    corpus::install_test_subscriber();
+
     let cases = corpus::test_cases();
     let case = cases.iter().find(|x| x.name == "zip64.zip").unwrap();
     let bytes = case.bytes();


### PR DESCRIPTION
Before, arguments to trace! weren't ever evaluated. Now they are, which means slower CI runs. But they're not printed, which hopefully means reasonable CI times, still.